### PR TITLE
Master

### DIFF
--- a/injectors/AR9280_as_AR946x.plist
+++ b/injectors/AR9280_as_AR946x.plist
@@ -29,6 +29,7 @@
 			<key>IONameMatch</key>
 			<array>
 				<string>pci168c,34</string>
+				<string>pci168c,36</string>
 			</array>
 			<key>IOProbeScore</key>
 			<integer>600</integer>


### PR DESCRIPTION
Add support for Dell Wireless 1707 (DW1707):
1. Chip: QCA9565
2. Bluetooth: 4.0
3. Bands: 802.11b/g/n  2.4GHz
4. A cheap M2 WI-Fi